### PR TITLE
Adds: one-dark theme for editorMarkdownThemeDark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.3.17] - 2023-12-28
+
+### Feature
+
+- Add One Dark theme (thanks to @mikicvi) (#113).
+
 ## [1.3.16] - 2023-12-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-plugin-macos-theme",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "keywords": [
     "joplin",
     "joplin-plugin",

--- a/src/css/codemirror/one-dark.css
+++ b/src/css/codemirror/one-dark.css
@@ -1,0 +1,143 @@
+/*
+  Name:       One Dark
+  Author:     Atom
+
+  Original One Dark syntax theme (https://github.com/codemirror/theme-one-dark)
+*/
+.cm-s-one-dark.CodeMirror {
+    background-color: #282c34;
+    color: #abb2bf;
+  }
+  
+.cm-s-one-dark.CodeMirror-gutters {
+    background: #282c34;
+    color: #7d8799;
+    border: none;
+  }
+  
+  .cm-s-one-dark.CodeMirror-guttermarker,
+  .cm-s-one-dark.CodeMirror-guttermarker-subtle,
+  .cm-s-one-dark.CodeMirror-linenumber {
+    color: #7d8799;
+  }
+  
+  .cm-s-one-dark.CodeMirror-cursor {
+    border-left: 1px solid #528bff;
+  }
+  
+  .cm-s-one-dark.CodeMirror-fat-cursor .cm-s-one-dark.CodeMirror-cursor {
+    background-color: #5d6d5c80 !important;
+  }
+  
+  .cm-s-one-dark.CodeMirror-animate-fat-cursor {
+    background-color: #5d6d5c80 !important;
+  }
+  
+  .cm-s-one-dark.CodeMirror-selected {
+    background: #3E4451;
+  }
+  
+  .cm-s-one-dark.CodeMirror-focused .cm-s-one-dark.CodeMirror-selected {
+    background: #3E4451;
+  }
+  
+  .cm-s-one-dark.CodeMirror-line::selection,
+  .cm-s-one-dark.CodeMirror-line>span::selection,
+  .cm-s-one-dark.CodeMirror-line>span>span::selection {
+    background: #3E4451;
+  }
+  
+  .cm-s-one-dark.CodeMirror-line::-moz-selection,
+  .cm-s-one-dark.CodeMirror-line>span::-moz-selection,
+  .cm-s-one-dark.CodeMirror-line>span>span::-moz-selection {
+    background: #3E4451;
+  }
+  
+  .cm-s-one-dark.CodeMirror-activeline-background {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  
+  .cm-s-one-dark .cm-keyword {
+    color: #c678dd;
+  }
+  
+  .cm-s-one-dark .cm-operator {
+    color: #56b6c2;
+  }
+  
+  .cm-s-one-dark .cm-variable-2 {
+    color: #abb2bf;
+  }
+  
+  .cm-s-one-dark .cm-variable-3,
+  .cm-s-one-dark .cm-type {
+    color: #61afef;
+  }
+  
+  .cm-s-one-dark .cm-builtin {
+    color: #d19a66;
+  }
+  
+  .cm-s-one-dark .cm-atom {
+    color: #61afef;
+  }
+  
+  .cm-s-one-dark .cm-number {
+    color: #d19a66;
+  }
+  
+  .cm-s-one-dark .cm-def {
+    color: #abb2bf;
+  }
+  
+  .cm-s-one-dark .cm-string {
+    color: #98c379;
+  }
+  
+  .cm-s-one-dark .cm-string-2 {
+    color: #d19a66;
+  }
+  
+  .cm-s-one-dark .cm-comment {
+    color: #7d8799;
+  }
+  
+  .cm-s-one-dark .cm-variable {
+    color: #d19a66;
+  }
+  
+  .cm-s-one-dark .cm-tag {
+    color: #d19a66;
+  }
+  
+  .cm-s-one-dark .cm-meta {
+    color: #abb2bf;
+  }
+  
+  .cm-s-one-dark .cm-attribute {
+    color: #c678dd;
+  }
+  
+  .cm-s-one-dark .cm-property {
+    color: #c678dd;
+  }
+  
+  .cm-s-one-dark .cm-qualifier {
+    color: #bad0f847;
+  }
+  
+  .cm-s-one-dark .cm-variable-3,
+  .cm-s-one-dark .cm-type {
+    color: #61b149;
+  }
+  
+  .cm-s-one-dark .cm-error {
+    color: #ffffff;
+    background-color: #ff5370;
+  }
+  
+  .cm-s-one-dark  .cmmatchingbracket {
+    text-decoration: underline;
+    color: white !important;
+  }
+  

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,6 +222,7 @@ joplin.plugins.register({
 					'xq-dark': 'xq-dark',
 					'yonce': 'yonce',
 					'zenburn': 'zenburn',
+					'one-dark': 'one-dark',
 				},
 			}
 		});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "id": "com.andrejilderda.macOSTheme",
   "app_min_version": "2.2.4",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "name": "macOS theme",
   "description": "Native looking macOS theme for Joplin. Also works on non-macOS devices.",
   "author": "Andre Jilderda",


### PR DESCRIPTION
#113 

Followed https://github.com/andrejilderda/joplin-macos-native-theme/blob/main/src/css/codemirror/material.css for layout.

Used https://github.com/codemirror/theme-one-dark as per issue.

Preview
![image](https://github.com/andrejilderda/joplin-macos-native-theme/assets/88291034/c5b0fcb8-2f00-49ff-a17f-2a8abdb52581)
