### PR TITLE
fix: hiding of plugin icons in editor toolbar (#105)

### DIFF
--- a/.changeset/warm-insects-repeat.md
+++ b/.changeset/warm-insects-repeat.md
@@ -1,0 +1,5 @@
+---
+"joplin-plugin-macos-theme": patch
+---
+
+fix: hiding of plugin icons in editor toolbar

--- a/src/scss/components/_components.editor.scss
+++ b/src/scss/components/_components.editor.scss
@@ -208,12 +208,8 @@
     }
 
     // markdown toggle
-    .tox-tbtn {
+    :has(.fa-markdown).tox-tbtn {
       @include toolbarButton();
-
-      * {
-        display: none !important;
-      }
 
       &::after {
         @include toolbarButtonIcon();
@@ -231,6 +227,13 @@
 
       &.richText-active::after {
         @include icon(text-below-photo);
+      }
+    }
+
+    // hide markdown buttons
+    :has(.fa-markdown).tox-tbtn {
+      * {
+        display: none !important;
       }
     }
 


### PR DESCRIPTION
fixes #105 