### PR TITLE
Fix #152 and #153

### DIFF
--- a/src/scss/components/_components.editor.scss
+++ b/src/scss/components/_components.editor.scss
@@ -748,13 +748,13 @@
     color: var(--g-secondaryLabelColor) !important;
 
     // increase click area, so that clicking on the tags also open the modal
-    &::after {
-      content: "";
-      position: absolute;
-      left: 0;
-      right: 0;
-      height: 100%;
-    }
+    // &::after {
+    //   content: "";
+    //   position: absolute;
+    //   left: 0;
+    //   right: 0;
+    //   height: 100%;
+    // }
   }
 
   .icon-tags {


### PR DESCRIPTION
Hello, I verified that by commenting the CSS rule in the editor file the buttons become clickable again and it is possible to change the note title.
Additionally, the bug prevented to use the Rich Editor plugin.

I checked on version 3.2.8, but it should work also in 3.1. I don't know the reason for the offending rule, so I just commented it.