### PR TITLE
Fix editor coloring (partial)

### DIFF
--- a/src/scss/components/_components.editor.scss
+++ b/src/scss/components/_components.editor.scss
@@ -745,7 +745,7 @@
 
   // label
   div > span {
-    color: var(--g-secondaryLabelColor) !important;
+    // color: var(--g-secondaryLabelColor) !important;
 
     // increase click area, so that clicking on the tags also open the modal
     &::after {


### PR DESCRIPTION
When working on #154, I verified that commenting also the remaining line in the CSS rules brings back the editor coloring. In any case, it does not apply the editor style selected in the options.