### PR TITLE
Update tag bar selector (fix #152 and #153 and restore editor coloring)

### DIFF
--- a/src/scss/components/_components.editor.scss
+++ b/src/scss/components/_components.editor.scss
@@ -729,7 +729,7 @@
 }
 
 // bottom tag bar
-.rli-editor > div > div > div > div:last-child {
+.rli-editor > div > div > div > div > div:last-child {
   > div {
     position: relative;
   }


### PR DESCRIPTION
Sorry for the previous PR, I fixed the tag bar accessor (I added a div in the hierarchy), this restores the functionalities of buttons #153, note title #152, and editor coloring. Tested on 3.2.8.

Still, it appears that editor styles cannot be modified.