### PR TITLE
fix: buttons in markdown editor not working #153

### DIFF
--- a/.changeset/famous-ties-tan.md
+++ b/.changeset/famous-ties-tan.md
@@ -1,0 +1,5 @@
+---
+"joplin-plugin-macos-theme": patch
+---
+
+fix: buttons in markdown editor not working #153

--- a/src/scss/components/_components.editor.scss
+++ b/src/scss/components/_components.editor.scss
@@ -42,6 +42,7 @@
 }
 
 @mixin toolbarDivider {
+  position: relative;
   padding-left: 0 !important;
   padding-right: 0 !important;
 


### PR DESCRIPTION
Should fix #153 properly.