### PR TITLE
fix: Fix tag-bar styles are applied to the note title

### DIFF
--- a/.changeset/fluffy-lamps-greet.md
+++ b/.changeset/fluffy-lamps-greet.md
@@ -1,0 +1,5 @@
+---
+"joplin-plugin-macos-theme": patch
+---
+
+fix: note title not editable #163

--- a/src/scss/components/_components.editor.scss
+++ b/src/scss/components/_components.editor.scss
@@ -734,7 +734,7 @@
 }
 
 // bottom tag bar
-.rli-editor > div > div > div > div:last-child {
+.tag-bar {
   > div {
     position: relative;
   }


### PR DESCRIPTION
# Summary

This pull request updates the CSS selector for the tag bar. Fixes #162.

The relevant CSS class name was added in https://github.com/laurent22/joplin/commit/f3e03d48bb1682e24d96b7462371fa9da9325322 (Joplin v2.0.2). As such, this shouldn't break compatibility with older versions of Joplin.

# Screenshots

## v3.1.22/before

![image](https://github.com/user-attachments/assets/90ba8b13-5b59-4e41-87e6-3b7ba5698125)

## v3.1.22/after

![screenshot: Looks identical to the before](https://github.com/user-attachments/assets/e6b47b59-d95c-40d4-ac34-e52ee5d02d31)


## v3.2.10/after

![screenshot: Shows the MacOS theme in Joplin 3.2.10. Looks similar to the "before" screenshot, but the toolbar icons are different](https://github.com/user-attachments/assets/02c084b1-8952-4091-a3ab-7fa09e357c3b)


