### PR TITLE
Fix: md editor dividers, dark theme md, title, toolbar, tag contents

### DIFF
--- a/.changeset/soft-flowers-occur.md
+++ b/.changeset/soft-flowers-occur.md
@@ -1,0 +1,6 @@
+---
+"joplin-plugin-macos-theme": patch
+---
+
+- fix: styling of editor dividers, dark theme, title, toolbar and tag contents
+- fix: styling of notebook folder when in all notes or tag view

--- a/src/scss/components/_components.editor.scss
+++ b/src/scss/components/_components.editor.scss
@@ -76,10 +76,10 @@
     background-color: transparent !important;
   }
 
-// title, toolbar, editor - background color -
-@media (prefers-color-scheme: dark) {
+  // title, toolbar, editor - background color -
+  @media (prefers-color-scheme: dark) {
     background-color: #1f1f1f;
-}
+  }
 
   // remove bg color when no note is selected when search returns no results
   > div > div {
@@ -742,6 +742,7 @@
 .tag-bar {
   > div {
     position: relative;
+    align-items: baseline !important;
   }
 
   button {
@@ -792,25 +793,26 @@
         margin-right: 0.8rem !important;
       }
     }
-	// prevent overlaying content, space between items
-	button {
-		display: contents !important;
+    // prevent overlaying content, space between items
+    button {
+      color: var(--g-secondaryLabelColor) !important;
+      display: contents !important;
 
-		&::after {
-		padding: 0.2rem 0.4rem;
-		content: ",";
-		}
+      &::after {
+        content: ", ";
+        white-space: pre;
+      }
 
-		&:last-child::after {
-		content: ""; // remove the comma after the last button
-		}
-	}
+      &:last-child::after {
+        padding-right: 1rem;
+        content: ""; // remove the comma after the last button
+      }
+    }
   }
 }
 
 // find in note (unused? replaced in the meantime?)
 .note-search-bar {
-  background-color: red !important;
   border-top-color: var(--g-gridColor) !important;
   padding-left: 0.8rem;
   position: relative;

--- a/src/scss/components/_components.editor.scss
+++ b/src/scss/components/_components.editor.scss
@@ -76,6 +76,11 @@
     background-color: transparent !important;
   }
 
+// title, toolbar, editor - background color -
+@media (prefers-color-scheme: dark) {
+    background-color: #1f1f1f;
+}
+
   // remove bg color when no note is selected when search returns no results
   > div > div {
     background-color: transparent !important;
@@ -487,7 +492,7 @@
   }
 
   // markdown editor
-  > div > div > div > div:not(:first-child) {
+  > div > div > div > div > div:not(:first-child) {
     .editor-toolbar {
       &:after {
         @include editorDivider();
@@ -787,6 +792,19 @@
         margin-right: 0.8rem !important;
       }
     }
+	// prevent overlaying content, space between items
+	button {
+		display: contents !important;
+
+		&::after {
+		padding: 0.2rem 0.4rem;
+		content: ",";
+		}
+
+		&:last-child::after {
+		content: ""; // remove the comma after the last button
+		}
+	}
   }
 }
 

--- a/src/scss/components/_components.editor.scss
+++ b/src/scss/components/_components.editor.scss
@@ -86,7 +86,7 @@
     background-color: transparent !important;
   }
 
-  > div > div > div > div {
+  > div > div > div > div > div {
     &:first-child {
       // note title
       .title-input {


### PR DESCRIPTION
Hey Andre, 

I'm not sure if these fixes are implemented in preferred, but I have tested locally and seem to address everything I reported in #165.

For toolbar dividers and horizontal dividers, the fix was adjusting a selector (additional div nesting in CM6).

Here is the preview with fixes implemented
![image](https://github.com/user-attachments/assets/a40b0cea-7c8b-45fa-8452-f58f217d90d5)
